### PR TITLE
Fixing janky scroll and improving memory page header CSS

### DIFF
--- a/app/assets/stylesheets/main.css.sass
+++ b/app/assets/stylesheets/main.css.sass
@@ -39,6 +39,7 @@
 /* SCREEN SIZE: SMALL MOBILES */
 @media (max-width: 480px)
   @import 'media/small_mobiles'
+  @import 'media/structured_small_mobiles'
 
 
 /* SCREEN SIZE: TABLETS */

--- a/app/assets/stylesheets/media/_desktop.css.sass
+++ b/app/assets/stylesheets/media/_desktop.css.sass
@@ -212,31 +212,31 @@ span.button.memories:hover
 
 /* ==================================== PAGINATION */
 
-.memories
-  .pagination-container
-    text-align: center
-
-    .pagination
-      span.disabled
-        color: lighten( $blue, 50% )
-        background: #eee
-
-        &:hover
-          color: lighten( $blue, 50% )
-
-      li
-        a
-          color: $blue
-        span.disabled, &:hover
-          color: lighten( $blue, 20% )
-          &:hover
-            color: lighten( $blue, 20% )
-
-        &.active
-          a
-            color: white
-            background: $blue
-            border: 1px solid darken( $blue, 5% )
+//.memories
+//  .pagination-container
+//    text-align: center
+//
+//    .pagination
+//      span.disabled
+//        color: lighten( $blue, 50% )
+//        background: #eee
+//
+//        &:hover
+//          color: lighten( $blue, 50% )
+//
+//      li
+//        a
+//          color: $blue
+//        span.disabled, &:hover
+//          color: lighten( $blue, 20% )
+//          &:hover
+//            color: lighten( $blue, 20% )
+//
+//        &.active
+//          a
+//            color: white
+//            background: $blue
+//            border: 1px solid darken( $blue, 5% )
 
 
 
@@ -265,6 +265,7 @@ span.button.memories:hover
             color: white
             background: $teal
             border: 1px solid darken( $teal, 5% )
+
 
 /* ==================================== TYPOGRAPHY */
 
@@ -513,25 +514,7 @@ h2, h3
   position: relative
 
 
-/* ================= STICKY FOOTER */
-
-
-html, body, #wrapper
-  height: 100%
-
-#wrapper
-  display: table
-  width: 100%
-
-/* ie7 and under*/
-#main-header, footer, #main
-  display: block
-#main-header, footer, #main
-  display: table-row
-
-/* height 1px on the header and footer is the sticky footer technique */
-#main-header, footer
-  height: 1px
+/* FOOTER */
 
 footer
   height: $desktop-footer-height
@@ -624,6 +607,7 @@ button#create-scrapbook-button
 
 .photo
   padding: 0
+
 
 /* ==================================== HOME PAGE */
 

--- a/app/assets/stylesheets/media/_mobiles.css.sass
+++ b/app/assets/stylesheets/media/_mobiles.css.sass
@@ -40,10 +40,6 @@
 .desktop
   display: none !important
 
-#wrapper
-  position: relative
-  overflow: auto
-
 #main-header
   width: 100%
   height: $mobile-header-height
@@ -510,12 +506,6 @@ section
   a
     @include word-wrap()
 
-
-.pagination
-  li.mobile
-    a, span
-      padding-left: 15px
-      padding-right: 15px
 
 /* profile pages */
 

--- a/app/assets/stylesheets/media/_structured_desktop.css.sass
+++ b/app/assets/stylesheets/media/_structured_desktop.css.sass
@@ -1,3 +1,172 @@
+/* ====== LAYOUT ====== */
+
+/* STICKY FOOTER */
+
+/* for browsers that support flexbox */
+body
+  display: flex
+  min-height: 100vh
+  flex-direction: column
+
+#wrapper
+  flex: 1
+  display: block
+  position: relative
+
+/* IE9 */
+html.ie9
+  height: 100%
+
+  body
+    display: table
+    width: 100%
+
+  body, #wrapper
+    height: 100%
+
+  #wrapper, footer
+    display: table-row
+
+
+/* ====== COMPONENTS ====== */
+
+/* BUTTONS */
+.button--memories
+  background-color: $blue
+  border: 1px solid darken( $blue, 10% )
+  text-shadow: 0px 1px 0px $blue
+  text-decoration: none
+  color: white
+
+  &:hover
+    background-color: darken( $blue, 20% )
+
+span.button--memories:hover
+  background-color: $blue !important
+  cursor: default
+
+.button--inactive
+  border: 1px solid rgba($navy-blue, 0.25)
+  background-color: rgba($navy-blue, 0.25)
+  color: $navy-blue
+  text-shadow: none
+
+  &.button--scrapbooks:hover
+    background-color: $teal
+    border: 1px solid $teal
+    color: white
+
+  &.button--memories:hover
+    background-color: $blue
+    border: 1px solid  $blue
+    color: white
+
+
+
+/* PAGE HEADER */
+.ec-page-header
+  padding: 2em 0
+
+.ec-page-header__title
+  margin: 0
+  text-align: center
+
+    // span
+    // display: block
+    // font-size: 0.8em
+    // font-weight: 300
+
+.ec-page-header__actions
+  border-bottom: $navy-blue 1px solid
+  border-top: $navy-blue 1px solid
+  margin-top: 2em
+  padding: 1em 0 0.5em 0
+
+  .button-group--left, .button-group--right
+    display: inline-block
+    position: relative
+
+  .button-group--left
+    label
+      float: left
+      margin-bottom: 0
+      padding: 0.5em 1em 0.5em 0
+
+    .button--memories
+      +border-radius(3px 0 0 3px)
+      float: left
+
+    .button--scrapbooks
+      +border-radius(0 3px 3px 0)
+      float: left
+      position: relative
+
+    a:active, span:active
+      text-decoration: none
+      top: 0
+
+  .button-group--right
+    float: right
+
+
+
+/* PAGINATION */
+
+.pagination-container
+  text-align: center
+
+.pagination
+  span.disabled
+    background: #eee
+
+    .memory-list &
+      color: lighten( $blue, 50% )
+
+      &:hover
+        color: lighten( $blue, 50% )
+
+    .scrapbook-list &
+      color: lighten( $teal, 50% )
+
+      &:hover
+        color: lighten( $teal, 50% )
+
+  li
+    a
+      .memory-list &
+        color: $blue
+
+      .scrapbook-list &
+        color: $teal
+
+    span.disabled, &:hover
+      .memory-list &
+        color: lighten( $blue, 20% )
+
+        &:hover
+          color: lighten( $blue, 20% )
+
+      .scrapbook-list &
+        color: lighten( $teal, 20% )
+
+        &:hover
+          color: lighten( $teal, 20% )
+
+    &.active
+      a
+        color: white
+
+        .memory-list &
+          background: $blue
+          border: 1px solid darken( $blue, 5% )
+
+        .scrapbook-list &
+          background: $teal
+          border: 1px solid darken( $teal, 5% )
+
+
+
+
 /* SCRAPBOOK */
 
 

--- a/app/assets/stylesheets/media/_structured_mobiles.css.sass
+++ b/app/assets/stylesheets/media/_structured_mobiles.css.sass
@@ -1,3 +1,16 @@
+/* ====== LAYOUT ====== */
+
+#wrapper
+  overflow: auto
+
+
+/* PAGINATION */
+.pagination
+  li.mobile
+    a, span
+      padding-left: 15px
+      padding-right: 15px
+
 /* Scrapbook */
 
 .scrapbook__info, .scrapbook__content

--- a/app/assets/stylesheets/media/_structured_small_mobiles.css.sass
+++ b/app/assets/stylesheets/media/_structured_small_mobiles.css.sass
@@ -1,0 +1,25 @@
+/* PAGE HEADER */
+.ec-page-header
+  text-align: center
+
+.ec-page-header__actions
+
+  .button-group--left, .button-group--right
+    display: inline-block
+
+  .button-group--left, .button-group--right
+    width: 100%
+
+  .button-group--left
+    label
+      display: block
+      width: 100%
+
+    .button
+      width: 50%
+
+  .button-group--right
+    float: none
+
+    .button
+      display: block

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -56,7 +56,7 @@
     <!--a class="desktop feedback" href="mailto:<%#= CONTACT_EMAIL %>?subject=<%#= URI::escape "#{APP_NAME} Feedback" %>">Feedback</a-->
     <div id="wrapper">
       <header id="main-header" class="container">
-        <div id="masthead" class="clearfix container">
+        <div id="masthead" class="clearfix">
           <div id="theNavBar" role="navigation" class="col-xs-12 col-sm-12">
             <button class="toggleMenu" type="button" role="button" aria-label="Open menu">
               <span id="menuText">MENU</span>
@@ -142,6 +142,7 @@
 
         </div> <!-- end masthead -->
       </header>
+
       <div id="main">
         <div class="flashes container">
           <% if show_verification_warning? -%>
@@ -165,35 +166,35 @@
 
           <%= content_for :modals %>
         </div>
-
       </div>
-      <footer>
-        <div class="container clearfix">
-          <div class="wrap">
-            <ul>
-              <li>
-                <%= link_to about_path do %>
-                  <span class="accessible-label">About this site</span>
-                  About
-                <% end -%>
-              </li>
-              <li><%= link_to 'Contact us', contact_path %></li>
-              <li><%= link_to 'Privacy and cookies', p_and_c_path %></li>
-              <li><%= link_to 'Terms and conditions', t_and_c_path %></li>
-            </ul>
-            <p>&copy; The City of Edinburgh Council 2014</p>
-          </div>
-          <a href="http://www.edinburgh.gov.uk/" id="councilLogo" class="" target="blank">
-            <span class="accessible-label">City of Edinburgh Council website</span>
-            <%= image_tag "edinburgh-council.png", alt: "The City of Edinburgh Council" %>
-          </a>
-          <a href="http://www.nesta.org.uk/" id="nestaLogo" target="blank">
-            <span class="accessible-label">Nesta website</span>
-            <%= image_tag "nesta.png", alt: "Nesta" %>
-          </a>
-        </div>
-      </footer>
     </div>
+
+    <footer>
+      <div class="container clearfix">
+        <div class="wrap">
+          <ul>
+            <li>
+              <%= link_to about_path do %>
+                <span class="accessible-label">About this site</span>
+                About
+              <% end -%>
+            </li>
+            <li><%= link_to 'Contact us', contact_path %></li>
+            <li><%= link_to 'Privacy and cookies', p_and_c_path %></li>
+            <li><%= link_to 'Terms and conditions', t_and_c_path %></li>
+          </ul>
+          <p>&copy; The City of Edinburgh Council 2014</p>
+        </div>
+        <a href="http://www.edinburgh.gov.uk/" id="councilLogo" class="" target="blank">
+          <span class="accessible-label">City of Edinburgh Council website</span>
+          <%= image_tag "edinburgh-council.png", alt: "The City of Edinburgh Council" %>
+        </a>
+        <a href="http://www.nesta.org.uk/" id="nestaLogo" target="blank">
+          <span class="accessible-label">Nesta website</span>
+          <%= image_tag "nesta.png", alt: "Nesta" %>
+        </a>
+      </div>
+    </footer>
 
     <script type="text/javascript">
       (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){

--- a/app/views/memories/_index.html.erb
+++ b/app/views/memories/_index.html.erb
@@ -1,12 +1,15 @@
 <div class="masonry-loading-spinner"><div class="spinner"></div></div>
+
 <div class="memory-container">
   <%= render partial: 'shared/pagination', locals: {items: memories} %>
+
   <div id="memories" class="masonry-grid">
     <div class="grid-sizer"></div>
     <% memories.each do |memory| %>
       <%= render partial: 'memories/memory_thumb', locals: {memory: memory} %>
     <% end %>
   </div>
+
   <%= render partial: 'shared/pagination', locals: {items: memories} %>
 </div>
 

--- a/app/views/memories/index.html.erb
+++ b/app/views/memories/index.html.erb
@@ -1,19 +1,21 @@
-<div class="container memories">
-  <div id="grid">
-    <header id="contentHeader" class="clearfix">
-      <h1>All memories</h1>
+<div class="container">
+  <header class="ec-page-header clearfix">
+    <h1 class="ec-page-header__title">All memories</h1>
 
-      <div class="actions clearfix">
-       <div class="viewingInfo clearfix">
-         <strong>Browse</strong>
-         <span class="button memories teal">Memories</span>
-         <%= link_to 'Scrapbooks', scrapbooks_path, :class => "button scrapbooks inactive" %>
-       </div>
-
-       <%= link_to 'Add a memory', new_my_memory_path, :class => "button memories float-right" %>
+    <div class="ec-page-header__actions clearfix">
+      <div class="button-group--left">
+        <label>Browse</label>
+        <span class="button button--memories">Memories</span>
+        <%= link_to 'Scrapbooks', scrapbooks_path, :class => "button button--scrapbooks button--inactive" %>
       </div>
 
-    </header>
+      <div class="button-group--right">
+        <%= link_to 'Add a memory', new_my_memory_path, :class => "button button--memories" %>
+      </div>
+    </div>
+  </header>
+
+  <div class="memory-list">
     <%= render partial: 'memories/index', locals: {memories: @memories} %>
   </div>
 </div>


### PR DESCRIPTION
This PR is all about fixing the janky scroll on mobile devices. It turned out to be the sticky footer code that was doing this and so I've swapped the table view method out for a flexbox approach instead. For browsers that don't support flexbox I'm still using the old method for now.

Whilst I was in there I also started to refactor the page header styles into something a bit more namespaced as it was picking up styles from elsewhere. Going to try it out on one page first (memories index page) and then roll out across the rest if it works. Might look into moving this content into the layout as it's used by all pages. However this will require content_for blocks so it might be a bit over engineered for future maintenance.

Signed-off-by: Alan Gardner <urfolomeus@gmail.com>