### PR TITLE
Honour whitespace

### DIFF
--- a/app/views/memories/_memory.html.erb
+++ b/app/views/memories/_memory.html.erb
@@ -41,7 +41,7 @@
     <div id="metadata" class="col-xs-12 col-md-6">
       <div id="about">
         <h3>About this memory</h3>
-        <p id="memory-description"><%= @memory.description %></p>
+        <div id="memory-description"><%= simple_format(@memory.description) %></div>
 
         <% if @memory.attribution.present? %>
           <p id="memory-attribution">

--- a/app/views/my/profile/show.html.erb
+++ b/app/views/my/profile/show.html.erb
@@ -28,7 +28,7 @@
         </p>
 
         <p><strong>Bio:</strong></p>
-        <p><%= @user.description %></p>
+        <p><%= simple_format(@user.description) %></p>
 
         <%= render partial: 'users/links', locals: {requested_user: @user} %>
       </div>

--- a/app/views/scrapbooks/_scrapbook.html.erb
+++ b/app/views/scrapbooks/_scrapbook.html.erb
@@ -25,7 +25,7 @@
       <h2>About this scrapbook</h2>
 
       <div class="scrapbook__info__description">
-        <%= @scrapbook.description %>
+        <%= simple_format(@scrapbook.description) %>
       </div>
 
       <div class="scrapbook__info__creator">

--- a/app/views/shared/_profile_header.html.erb
+++ b/app/views/shared/_profile_header.html.erb
@@ -21,7 +21,7 @@
 
   <% end -%>
 
-  <p class="sub"><%= requested_user.description %></p>
+  <div class="sub"><%= simple_format(requested_user.description) %></div>
 
   <%= render partial: 'users/links', locals: {requested_user: requested_user} %>
 

--- a/spec/support/shared_examples/views/profile_header_examples.rb
+++ b/spec/support/shared_examples/views/profile_header_examples.rb
@@ -39,7 +39,7 @@ RSpec.shared_examples 'a profile headed page' do
       end
 
       it "displays the requested user's description" do
-        expect(rendered).to have_css('p.sub', text: requested_user.description)
+        expect(rendered).to have_css('.sub', text: requested_user.description)
       end
 
       context "when the user has no links" do
@@ -87,7 +87,7 @@ RSpec.shared_examples 'a profile headed page' do
         end
 
         it "displays the requested user's description" do
-          expect(rendered).to have_css('p.sub', text: requested_user.description)
+          expect(rendered).to have_css('.sub', text: requested_user.description)
         end
 
         context "when the user has no links" do
@@ -129,7 +129,7 @@ RSpec.shared_examples 'a profile headed page' do
         end
 
         it "displays the requested user's description" do
-          expect(rendered).to have_css('p.sub', text: requested_user.description)
+          expect(rendered).to have_css('.sub', text: requested_user.description)
         end
 
         context "when the user has no links" do


### PR DESCRIPTION
Employ simple formatting to convert descriptions on memories, scrapbooks and user profile bios into HTML markup. This allows whitespace to be honoured rather than ignored and also has the nice side effect of allowing other markup in descriptions.